### PR TITLE
Added safeguarding for qb value on wordPair deletion and save

### DIFF
--- a/src/controllers/creator.coffee
+++ b/src/controllers/creator.coffee
@@ -19,7 +19,12 @@ angular.module 'matching', ['ngAnimate']
 	$scope.addWordPair = (q=null, a=null, media=[0,0], id='') ->
 		$scope.widget.wordPairs.push {question:q, answer:a, media:media, id:id}
 
-	$scope.removeWordPair = (index) -> $scope.widget.wordPairs.splice(index, 1)
+	$scope.removeWordPair = (index) ->
+		$scope.widget.wordPairs.splice(index, 1)
+
+		# Update the question bank value if it's greater than the number of word pairs
+		if($scope.enableQuestionBank && $scope.questionBankVal > $scope.widget.wordPairs.length)
+			$scope.questionBankVal = $scope.questionBankValTemp = $scope.widget.wordPairs.length
 
 	$scope.removeAudio = (index, which) -> $scope.widget.wordPairs[index].media.splice(which, 1, 0)
 
@@ -128,11 +133,19 @@ angular.module 'matching', ['ngAnimate']
 		assets
 
 	_buildSaveData = ->
+
+		# Update question bank value in case it happens to be greater than the number of word pairs, to avoid errors on player side
+		if $scope.questionBankVal > $scope.widget.wordPairs.length then $scope.questionBankVal = $scope.questionBankValTemp = $scope.widget.wordPairs.length
+
 		_qset.items = []
-		_qset.options = {caseSensitive: null, enableQuestionBank: $scope.enableQuestionBank, questionBankVal: $scope.questionBankVal}
 		_qset.items[0] =
 			name: "null"
 			items: []
+
+		_qset.options =
+			enableQuestionBank: $scope.enableQuestionBank
+			questionBankVal: $scope.questionBankVal
+
 		wordPairs = $scope.widget.wordPairs
 
 		return false if not wordPairs.length

--- a/src/controllers/creator.coffee
+++ b/src/controllers/creator.coffee
@@ -143,6 +143,7 @@ angular.module 'matching', ['ngAnimate']
 			items: []
 
 		_qset.options =
+			caseSensitive: null
 			enableQuestionBank: $scope.enableQuestionBank
 			questionBankVal: $scope.questionBankVal
 


### PR DESCRIPTION
Basically just added a check on both save and word pair deletion, to update the question bank value if it's higher than that of the word pair count. This way, the player won't encounter a weird error using invalid question bank data. 

Fixes #49 . 